### PR TITLE
gulp-nav on windows

### DIFF
--- a/gulp-nav.coffee
+++ b/gulp-nav.coffee
@@ -20,6 +20,7 @@
 
 {basename} = require 'path'
 through = require 'through2'
+slash = require 'slash'
 {relative, resolve} = require './web-path'
 
 module.exports = ({sources, targets, titles, orders, skips, hrefExtension,
@@ -60,7 +61,7 @@ module.exports = ({sources, targets, titles, orders, skips, hrefExtension,
         if skip of source and source[skip]
           return transformCallback null, file
       # normalize the path and break it into its constituent elements
-      path = resolve '/', file.relative
+      path = resolve '/', slash(file.relative)
         .replace /index\.[^/]+$/, ''          # index identified with directory
         .replace /\.[^./]+$/, '.' + hrefExtension     # e.g. '.jade' -> '.html'
       # find the right spot for the new resource

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-nav",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "description": "gulp plugin to help build navigation elements",
   "keywords": [
     "gulpplugin",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/jessaustin/gulp-nav",
   "dependencies": {
+    "slash": "1.0.0",
     "through2": ">=0.5"
   },
   "devDependencies": {

--- a/web-path.coffee
+++ b/web-path.coffee
@@ -23,7 +23,7 @@ trimBackToSlash = (str) ->    # this would be a one-liner if we had look-behind
 
 module.exports =
   resolve: (from..., to) ->
-    (path.resolve (trimBackToSlash f for f in from)..., to) +
+    (path.posix.resolve (trimBackToSlash f for f in from)..., to) +
     if to.match /.\/\.?\.?$/ then '/' else ''
   relative: (from, to) ->
-    (path.relative (trimBackToSlash from), to) or '.'
+    (path.posix.relative (trimBackToSlash from), to) or '.'


### PR DESCRIPTION
- added slash module to normalize relative file paths across OS
- enforce usage of posix style file paths otherwise would default to OS specific
- bumped version to `0.2.0`

gulp-test pass and my website works
will test against other versions of Windows
